### PR TITLE
Replace obsoleted AC_PROG_LIBTOOL macro

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -102,7 +102,7 @@ if [[ "$with_asio" = "yes" ] || [ "$enable_cxx" = "yes" ]] ; then
        AC_PROG_CXX
 fi
 AC_LIBTOOL_WIN32_DLL
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PATH_PROG(AR, ar, no)


### PR DESCRIPTION
Since libtool version 1.9b (2004-08-29) AC_PROG_LIBTOOL is obsoleted
and replaced by LT_INIT.